### PR TITLE
feature: add "react-hooks/exhaustive-deps" lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,5 +14,6 @@ module.exports = {
     rules: {
         "react/react-in-jsx-scope": "off",
         "react/jsx-uses-react": "off",
+        "react-hooks/exhaustive-deps": "warn"
     },
 };


### PR DESCRIPTION
Così il linter vi segnala anche quando vi dimenticate la dipendenza nell'hook 👀